### PR TITLE
Fixed package.json for newer version of the Unity Package Manager

### DIFF
--- a/LICENSE.md.meta
+++ b/LICENSE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ca65d0aa5bb2e65498951bbd71d21ace
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a375268139388f44fa7e4f7cc8f8729d
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.siccity.gltfutility",
     "displayName": "GLTFUtility",
-    "version": "1.0",
+    "version": "1.0.0",
     "unity": "2018.2.18f1",
     "keywords": ["glTF", "import"],
     "description": "Lightweight glTF loader."

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.siccity.gltfutility",
     "displayName": "GLTFUtility",
-    "version": "1.0.0",
+    "version": "0.6.0",
     "unity": "2018.2",
     "keywords": ["glTF", "import"],
     "description": "Lightweight glTF loader."

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "com.siccity.gltfutility",
     "displayName": "GLTFUtility",
     "version": "1.0.0",
-    "unity": "2018.2.18f1",
+    "unity": "2018.2",
     "keywords": ["glTF", "import"],
     "description": "Lightweight glTF loader."
 }


### PR DESCRIPTION
Requires version to be SemVer, e.g.: 1.0.0
Requires unity version to be: <year>.<version>

Optimally the version should be 0.6.0 to reflect the one published under releases.