### PR TITLE
Added assembly definition files

### DIFF
--- a/GLTFUtility.asmdef
+++ b/GLTFUtility.asmdef
@@ -1,0 +1,15 @@
+{
+    "name": "GLTFUtility",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
+}

--- a/GLTFUtility.asmdef.meta
+++ b/GLTFUtility.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 774f0e7b520e24644b448f5ac7fa5d94
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LICENSE.md.meta
+++ b/LICENSE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ca65d0aa5bb2e65498951bbd71d21ace
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a375268139388f44fa7e4f7cc8f8729d
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.siccity.gltfutility",
     "displayName": "GLTFUtility",
-    "version": "1.0",
+    "version": "1.0.0",
     "unity": "2018.2.18f1",
     "keywords": ["glTF", "import"],
     "description": "Lightweight glTF loader."

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.siccity.gltfutility",
     "displayName": "GLTFUtility",
-    "version": "1.0.0",
+    "version": "0.6.0",
     "unity": "2018.2",
     "keywords": ["glTF", "import"],
     "description": "Lightweight glTF loader."

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "com.siccity.gltfutility",
     "displayName": "GLTFUtility",
     "version": "1.0.0",
-    "unity": "2018.2.18f1",
+    "unity": "2018.2",
     "keywords": ["glTF", "import"],
     "description": "Lightweight glTF loader."
 }


### PR DESCRIPTION
Newer Unity versions also requires assembly definition files to compile packages loaded as read-only by the package manager. Tested and working with Unity 2019.1.8f1.

I have configured the assembly to only be compiled and included in the Editor. Please correct this, if any of it should be available at runtime.

Thanks for making and sharing this great plugin! =)