### PR TITLE
Add flag in settings to set clips to legacy

### DIFF
--- a/Scripts/Importer.cs
+++ b/Scripts/Importer.cs
@@ -142,7 +142,7 @@ namespace Siccity.GLTFUtility {
 			skinTask.RunSynchronously();
 			GLTFNode.ImportTask nodeTask = new GLTFNode.ImportTask(gltfObject.nodes, meshTask, skinTask, gltfObject.cameras);
 			nodeTask.RunSynchronously();
-			animations = gltfObject.animations.Import(accessorTask.Result, nodeTask.Result);
+			animations = gltfObject.animations.Import(accessorTask.Result, nodeTask.Result, importSettings);
 
 			return nodeTask.Result.GetRoot();
 		}

--- a/Scripts/Settings/ImportSettings.cs
+++ b/Scripts/Settings/ImportSettings.cs
@@ -10,5 +10,6 @@ namespace Siccity.GLTFUtility {
 		public bool materials = true;
 		[FormerlySerializedAs("shaders")]
 		public ShaderSettings shaderOverrides = new ShaderSettings();
+		public bool useLegacyClips;
 	}
 }

--- a/Scripts/Spec/GLTFAnimation.cs
+++ b/Scripts/Spec/GLTFAnimation.cs
@@ -53,8 +53,7 @@ namespace Siccity.GLTFUtility {
 			result.clip = new AnimationClip();
 			result.clip.name = name;
 
-			if (importSettings.useLegacyClips)
-			{
+			if (importSettings.useLegacyClips) {
 				result.clip.legacy = true;
 			}
 

--- a/Scripts/Spec/GLTFAnimation.cs
+++ b/Scripts/Spec/GLTFAnimation.cs
@@ -48,10 +48,15 @@ namespace Siccity.GLTFUtility {
 		}
 #endregion
 
-		public ImportResult Import(GLTFAccessor.ImportResult[] accessors, GLTFNode.ImportResult[] nodes) {
+		public ImportResult Import(GLTFAccessor.ImportResult[] accessors, GLTFNode.ImportResult[] nodes, ImportSettings importSettings) {
 			ImportResult result = new ImportResult();
 			result.clip = new AnimationClip();
 			result.clip.name = name;
+
+			if (importSettings.useLegacyClips)
+			{
+				result.clip.legacy = true;
+			}
 
 			for (int i = 0; i < channels.Length; i++) {
 				Channel channel = channels[i];
@@ -129,12 +134,12 @@ namespace Siccity.GLTFUtility {
 	}
 
 	public static class GLTFAnimationExtensions {
-		public static GLTFAnimation.ImportResult[] Import(this List<GLTFAnimation> animations, GLTFAccessor.ImportResult[] accessors, GLTFNode.ImportResult[] nodes) {
+		public static GLTFAnimation.ImportResult[] Import(this List<GLTFAnimation> animations, GLTFAccessor.ImportResult[] accessors, GLTFNode.ImportResult[] nodes, ImportSettings importSettings) {
 			if (animations == null) return null;
 
 			GLTFAnimation.ImportResult[] results = new GLTFAnimation.ImportResult[animations.Count];
 			for (int i = 0; i < results.Length; i++) {
-				results[i] = animations[i].Import(accessors, nodes);
+				results[i] = animations[i].Import(accessors, nodes, importSettings);
 				if (string.IsNullOrEmpty(results[i].clip.name)) results[i].clip.name = "animation" + i;
 			}
 			return results;


### PR DESCRIPTION
This is very similar to #37 except it has the requested changes of allowing users to specify whether they'd like legacy clips or not.

I'm not sure if the:
```
if(node != null) {
  relativePath = $"{node.transform.name}/{relativePath}";
}
```
is needed, so let me know. My runtime tests didn't require it.

Also, are additional changes needed for animations in Async? Maybe that's handled but I couldn't follow the logic.

## Usage
```
ImportSettings settings = new ImportSettings
{
    useLegacyClips = true
};
GameObject obj = Importer.LoadFromFile("path/to/file", settings, out GLTFAnimation.ImportResult[] animations, Format.AUTO);

foreach(GLTFAnimation.ImportResult result in animations)
{
    Debug.Log($"{result.clip.name} : {result.clip.legacy}");
}
```