### PR TITLE
Allow embedded image data

### DIFF
--- a/Scripts/Spec/GLTFImage.cs
+++ b/Scripts/Spec/GLTFImage.cs
@@ -61,9 +61,17 @@ namespace Siccity.GLTFUtility {
 					imageData = new ImageData[images.Count];
 					for (int i = 0; i < imageData.Length; i++) {
 						string fullUri = directoryRoot + images[i].uri;
-						if (!string.IsNullOrEmpty(images[i].uri) && File.Exists(fullUri)) {
-							byte[] bytes = File.ReadAllBytes(fullUri);
-							imageData[i] = new ImageData(bytes, fullUri);
+						if (!string.IsNullOrEmpty(images[i].uri)) {
+							if (File.Exists(fullUri)) {
+								// If the file is found at fullUri, read it
+								byte[] bytes = File.ReadAllBytes(fullUri);
+								imageData[i] = new ImageData(bytes, fullUri);
+							} else if(images[i].uri.StartsWith("data:")) {
+								// If the image is embedded, find its Base64 content and save as byte array
+								string content = images[i].uri.Split(',').Last();
+								byte[] imageBytes = Convert.FromBase64String(content);
+								imageData[i] = new ImageData(imageBytes);
+							}
 						} else if (images[i].bufferView.HasValue && !string.IsNullOrEmpty(images[i].mimeType)) {
 							byte[] bytes = bufferViewTask.Result[images[i].bufferView.Value].bytes;
 							imageData[i] = new ImageData(bytes);


### PR DESCRIPTION
Partially solves #42 by loading embedded image data.

Tested with https://github.com/KhronosGroup/glTF-Sample-Models/blob/master/2.0/Duck/glTF-Embedded/Duck.gltf.

If there are any other models you'd like tested let me know.

I can look into the loading of remote textures if you'd like, but that will add a web request component to GTLFUtility with some added complexity (image processing will block texture loading). I'm less familiar with Async tasks, but if you have any ideas there about structure I'm happy to help.