### PR TITLE
Add ByteStride support for vertex attributes

### DIFF
--- a/Scripts/Spec/GLTFAccessor.cs
+++ b/Scripts/Spec/GLTFAccessor.cs
@@ -124,6 +124,7 @@ namespace Siccity.GLTFUtility {
 					Color32 color = Color.black;
 					for (int i = 0; i < count; i++) {
 						int startIndex = i * componentSize;
+						if (byteStride > 0) startIndex = i * byteStride;
 						color.r = bytes[startIndex];
 						startIndex += componentTypeSize;
 						color.g = bytes[startIndex];
@@ -141,6 +142,7 @@ namespace Siccity.GLTFUtility {
 					Func<byte[], int, float> converter = GetFloatConverter();
 					for (int i = 0; i < count; i++) {
 						int startIndex = i * componentSize;
+						if (byteStride > 0) startIndex = i * byteStride;
 						colors[i].r = converter(bytes, startIndex);
 						startIndex += componentTypeSize;
 						colors[i].g = converter(bytes, startIndex);
@@ -209,6 +211,7 @@ namespace Siccity.GLTFUtility {
 				Func<byte[], int, float> converter = GetFloatConverter();
 				for (int i = 0; i < count; i++) {
 					int startIndex = i * componentSize;
+					if (byteStride > 0) startIndex = i * byteStride;
 					floats[i] = converter(bytes, startIndex);
 				}
 				return floats;
@@ -222,6 +225,7 @@ namespace Siccity.GLTFUtility {
 				Func<byte[], int, int> converter = GetIntConverter();
 				for (int i = 0; i < count; i++) {
 					int startIndex = i * componentSize;
+					if (byteStride > 0) startIndex = i * byteStride;
 					ints[i] = converter(bytes, startIndex);
 				}
 				return ints;

--- a/Scripts/Spec/GLTFAccessor.cs
+++ b/Scripts/Spec/GLTFAccessor.cs
@@ -44,6 +44,7 @@ namespace Siccity.GLTFUtility {
 #region Import
 		public class ImportResult {
 			public byte[] bytes;
+			public int byteStride;
 			public int count;
 			public GLType componentType;
 			public AccessorType type;
@@ -101,6 +102,7 @@ namespace Siccity.GLTFUtility {
 				Func<byte[], int, float> converter = GetFloatConverter();
 				for (int i = 0; i < count; i++) {
 					int startIndex = i * componentSize;
+					if (byteStride > 0) startIndex = i * byteStride;
 					verts[i].x = converter(bytes, startIndex);
 					startIndex += componentTypeSize;
 					verts[i].y = converter(bytes, startIndex);
@@ -167,6 +169,7 @@ namespace Siccity.GLTFUtility {
 				Func<byte[], int, float> converter = GetFloatConverter();
 				for (int i = 0; i < count; i++) {
 					int startIndex = i * componentSize;
+					if (byteStride > 0) startIndex = i * byteStride;
 					verts[i].x = converter(bytes, startIndex);
 					startIndex += componentTypeSize;
 					verts[i].y = converter(bytes, startIndex);
@@ -189,6 +192,7 @@ namespace Siccity.GLTFUtility {
 				Func<byte[], int, float> converter = GetFloatConverter();
 				for (int i = 0; i < count; i++) {
 					int startIndex = i * componentSize;
+					if (byteStride > 0) startIndex = i * byteStride;
 					verts[i].x = converter(bytes, startIndex);
 					startIndex += componentTypeSize;
 					verts[i].y = converter(bytes, startIndex);
@@ -310,6 +314,12 @@ namespace Siccity.GLTFUtility {
 				}
 			}
 
+			public static bool ValidateByteStride(int byteStride) {
+				if (byteStride >= 4 && byteStride <= 252 && byteStride % 4 == 0) return true;
+				Debug.Log("ByteStride of " + byteStride + " is invalid. Ignoring.");
+				return false;
+			}
+
 			private static bool ValidateAccessorType(AccessorType type, AccessorType expected) {
 				if (type == expected) return true;
 				else {
@@ -335,6 +345,10 @@ namespace Siccity.GLTFUtility {
 			result.componentType = componentType;
 			result.type = type;
 			result.count = count;
+			// If an optional byteStride was added on bufferView in file, and it matches spec requirements
+			if (bufferView.byteStride.HasValue && ImportResult.ValidateByteStride((int)bufferView.byteStride)) {
+				result.byteStride = (int)bufferView.byteStride;
+			}
 			return result;
 		}
 

--- a/Scripts/Spec/GLTFBufferView.cs
+++ b/Scripts/Spec/GLTFBufferView.cs
@@ -19,6 +19,7 @@ namespace Siccity.GLTFUtility {
 
 		public class ImportResult {
 			public byte[] bytes;
+			public int? byteStride;
 
 			public byte[] GetBytes(int byteOffset = 0) {
 				if (byteOffset != 0) return bytes.SubArray(byteOffset, bytes.Length - byteOffset);
@@ -36,6 +37,9 @@ namespace Siccity.GLTFUtility {
 						GLTFBuffer.ImportResult buffer = bufferTask.Result[bufferViews[i].buffer];
 						ImportResult result = new ImportResult();
 						result.bytes = buffer.bytes.SubArray(byteOffset, byteLength);
+						if (bufferViews[i].byteStride.HasValue) {
+							result.byteStride = bufferViews[i].byteStride;
+						}
 						Result[i] = result;
 					}
 				});


### PR DESCRIPTION
First pass on adding ByteStride support for GLTFUtility #40 .

Critiques welcome, as byte navigation isn't my strong suit. The rationale with only adding this to Vec2, Vec3, and Vec4 is that those were the accessor types listed under the [meshes section](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#meshes) in the spec for vertex attributes. But my knowledge there is weaker, so let me know.

The example model I was using to test against for before and after is the [BoxInterleaved](https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxInterleaved/glTF-Embedded/BoxInterleaved.gltf) from the GLTF Sample Models. More interleaved model tests are welcome!

### Notes on Monster.GLB
I'm not certain that ByteStride is the issue here. From what I've tested, both Monster.GLTF and Monster.GLB have identical JSON. But the GLTF version loads perfectly fine using GLTFUtility. Also, the Monster JSON doesn't use Interleaving accessors. GLTFUtility should load it fine even without knowing how to handle bytestrides because the `componentType * num of components` should equal the bytestride. This could be a flaw in my implementation though, exploration there is welcome!