### PR TITLE
Left-handed/right-handed conversion fixes during GLTF import.

### DIFF
--- a/Scripts/Converters/QuaternionConverter.cs
+++ b/Scripts/Converters/QuaternionConverter.cs
@@ -11,6 +11,9 @@ namespace Siccity.GLTFUtility.Converters {
 	[Preserve] public class QuaternionConverter : JsonConverter {
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) {
 			Quaternion q = (Quaternion) value;
+			// TODO: We need to apply a left-handed to right-handed axis
+			//       flip here during export in the same way as we handle
+			//       it during import.
 			writer.WriteStartArray();
 			writer.WriteValue(q.x);
 			writer.WriteValue(q.y);
@@ -19,9 +22,20 @@ namespace Siccity.GLTFUtility.Converters {
 			writer.WriteEndArray();
 		}
 
+		// We need to convert the system from a right-handed system that GLTF
+		// supports into a left-handed system that Unity supports.  These
+		// 'flip' values will enable an X-axis switch.
+		static float xFlip =  1.0f;
+		static float yFlip = -1.0f;
+		static float zFlip = -1.0f;
+		static float wFlip =  1.0f;
+
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) {
 			float[] floatArray = serializer.Deserialize<float[]>(reader);
-			return new Quaternion(floatArray[0], floatArray[1], -floatArray[2], -floatArray[3]);
+			return new Quaternion(	xFlip * floatArray[0],
+						yFlip * floatArray[1],
+						zFlip * floatArray[2],
+						wFlip * floatArray[3]);
 		}
 
 		public override bool CanConvert(Type objectType) {

--- a/Scripts/Converters/TranslationConverter.cs
+++ b/Scripts/Converters/TranslationConverter.cs
@@ -11,6 +11,9 @@ namespace Siccity.GLTFUtility.Converters {
 	[Preserve] public class TranslationConverter : JsonConverter {
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) {
 			Vector3 pos = (Vector3) value;
+			// TODO: We need to apply the same kind of left-handed to right-handed
+			//       axis flip here during export in the same way as we handle
+			//       it during import.
 			writer.WriteStartArray();
 			writer.WriteValue(pos.x);
 			writer.WriteValue(pos.y);
@@ -18,9 +21,18 @@ namespace Siccity.GLTFUtility.Converters {
 			writer.WriteEndArray();
 		}
 
+		// We need to convert the system from a right-handed system that GLTF 
+		// supports into a left-handed system that Unity supports.  These 'flip'
+		// values will enable an X-axis switch.
+		static float xFlip = -1.0f;
+		static float yFlip =  1.0f;
+		static float zFlip =  1.0f;
+
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) {
 			float[] floatArray = serializer.Deserialize<float[]>(reader);
-			return new Vector3(floatArray[0], floatArray[1], -floatArray[2]);
+			return new Vector3(xFlip * floatArray[0],
+					   yFlip * floatArray[1],
+					   zFlip * floatArray[2]);
 		}
 
 		public override bool CanConvert(Type objectType) {

--- a/Scripts/Extensions.cs
+++ b/Scripts/Extensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using UnityEngine;
 
@@ -23,6 +23,10 @@ namespace Siccity.GLTFUtility {
 		}
 
 		public static void UnpackTRS(this Matrix4x4 trs, ref Vector3 position, ref Quaternion rotation, ref Vector3 scale) {
+			// TODO: We may need to apply a left-handed to right-handed axis flip
+			//       here as we're doing in other 'import' methods and functions.
+			//       Right now we have no way to test this, so for now, we'll leave
+			//       these older conversions as-is.
 			position = trs.GetColumn(3);
 			position.z = -position.z;
 			rotation = trs.rotation;

--- a/Scripts/Spec/GLTFAnimation.cs
+++ b/Scripts/Spec/GLTFAnimation.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
@@ -84,6 +84,13 @@ namespace Siccity.GLTFUtility {
 						AnimationCurve posY = new AnimationCurve();
 						AnimationCurve posZ = new AnimationCurve();
 						for (int k = 0; k < keyframeInput.Length; k++) {
+							// NOTE: We may need to apply a left-handed
+							//       to right-handed axis flip here
+							//       to account for the coordinate
+							//       differences between GLTF and 
+							//       Unity.  But right now we have
+							//       no way to test this, so we'll
+							//       leave it as-is.
 							posX.AddKey(keyframeInput[k], pos[k].x);
 							posY.AddKey(keyframeInput[k], pos[k].y);
 							posZ.AddKey(keyframeInput[k], -pos[k].z);
@@ -99,6 +106,13 @@ namespace Siccity.GLTFUtility {
 						AnimationCurve rotZ = new AnimationCurve();
 						AnimationCurve rotW = new AnimationCurve();
 						for (int k = 0; k < keyframeInput.Length; k++) {
+							// NOTE: We may need to apply a left-handed
+							//       to right-handed axis flip here
+							//       to account for the coordinate
+							//       differences between GLTF and 
+							//       Unity.  But right now we have
+							//       no way to test this, so we'll
+							//       leave it as-is.
 							rotX.AddKey(keyframeInput[k], rot[k].x);
 							rotY.AddKey(keyframeInput[k], rot[k].y);
 							rotZ.AddKey(keyframeInput[k], -rot[k].z);

--- a/Scripts/Spec/GLTFSkin.cs
+++ b/Scripts/Spec/GLTFSkin.cs
@@ -62,22 +62,15 @@ namespace Siccity.GLTFUtility {
 			if (inverseBindMatrices.HasValue) {
 				result.inverseBindMatrices = accessors[inverseBindMatrices.Value].ReadMatrix4x4();
 				for (int i = 0; i < result.inverseBindMatrices.Length; i++) {
-					// Flip the matrix from GLTF to Unity format. This was done through trial and error, i can't explain it.
+					// Flip the matrix from GLTF to Unity format, which
+					// is a left-handed coordinate system (not the right-
+					// handed system that GLTF uses).  This basically means
+					// that we have to flip everything about the X axis.
 					Matrix4x4 m = result.inverseBindMatrices[i];
-					Vector4 row0 = m.GetRow(0);
-					row0.z = -row0.z;
-					Vector4 row1 = m.GetRow(1);
-					row1.z = -row1.z;
-					Vector4 row2 = m.GetRow(2);
-					row2.x = -row2.x;
-					row2.y = -row2.y;
-					Vector4 row3 = m.GetRow(3);
-					row3.z = -row3.z;
-					m.SetColumn(0, row0);
-					m.SetColumn(1, row1);
-					m.SetColumn(2, row2);
-					m.SetColumn(3, row3);
-					result.inverseBindMatrices[i] = m;
+					Vector3 scale = new Vector3(-1, 1, 1);
+					Matrix4x4 convert = Matrix4x4.Scale(scale);
+					Matrix4x4 m2 = convert * m * convert;
+					result.inverseBindMatrices[i] = m2.transpose;
 				}
 			}
 			return result;


### PR DESCRIPTION
Hi Thor,

when applying animations (loaded in via fbx) to our humanoid characters, we noticed that they would behave very differently from what we are used to. Both in terms of blend shapes as well as bone based animations. We figured out that there were two underlying issues:

* correct conversion from gltf RHS to unity LHS
* correct conversion from gltf 0-1 to unity 0-100 blend-shapes

Both are addressed in this PR.

Unfortunately we did not have the time to get the change applied throughout the complete plugin. In general Export functions have not been updated. Animation loading related code was not touched either, it's import might need to be changed in consistency with these changes.