### PR TITLE
Implement BlendShape Animation with keyframe compression, Stepped and Linear Interpolation Modes, Custom framerate for imported animation clips, and package dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,18 @@
-[![Discord](https://img.shields.io/discord/361769369404964864.svg)](https://discord.gg/qgPrHv4)
-[![GitHub issues](https://img.shields.io/github/issues/Siccity/GLTFUtility.svg)](https://github.com/Siccity/GLTFUtility/issues)
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/Siccity/GLTFUtility/master/LICENSE.md)
-
 ## GLTFUtility
-Allows you to import and export glTF files during runtime and in editor.
-glTF is a new opensource 3d model transmission format which supports everything you'll ever need from a format in Unity.
-[Read more about glTF here](https://www.khronos.org/gltf/)
+This project adds a few animation features into [Siccity](https://github.com/Siccity)'s excellent [GLTFUtility](https://github.com/Siccity/GLTFUtility):
 
-![2019-04-01_00-46-27](https://user-images.githubusercontent.com/6402525/55296304-b2aa5880-5417-11e9-89a8-78ab540dc126.gif)
-![image](https://user-images.githubusercontent.com/6402525/55296353-7297a580-5418-11e9-8e76-5078680ee0d3.png)
-![image](https://user-images.githubusercontent.com/6402525/55296436-bd65ed00-5419-11e9-9723-31225b99450b.png)
-
-
-### What makes GLTFUtility different?
-Focusing on simplicity and ease of use, GLTFUtility aims to be an import-and-forget solution, keeping consistency with built-in functionality.
+* Animate blend shapes
+* Animate with stepped and linear interpolation modes
+* Force animations to use a specific interpolation mode
+* Cut out redundant blend shape animation key frames
+* Set a custom frame rate on imported animation clips
+* Don't worry about installing package dependencies
 
 ### Installation
-1. GLTFUtility requires Newtonsoft Json to be installed in your project.
-    * Official upm package: `"com.unity.nuget.newtonsoft-json": "2.0.0-preview",`
-    * Unofficial Asset Store: [link](https://assetstore.unity.com/packages/tools/input-management/json-net-for-unity-11347)
-    * Unofficial git repo: [link](https://github.com/jilleJr/Newtonsoft.Json-for-Unity)
+Open Unity's Package Manager and add the package with the git URL: <https://github.com/sprylyltd/GLTFUtility.git>.
 
-2. Choose *one* of the following:
-    * Download [.zip](https://github.com/Siccity/GLTFUtility/archive/master.zip) and extract to your project assets
-    * Download latest [.unitypackage](https://github.com/Siccity/GLTFUtility/releases) and unpack to your projects assets
-    * (git) Clone into your assets folder `git clone git@github.com:Siccity/GLTFUtility.git`
-    * (git) Add repo as submodule `git submodule add git@github.com:Siccity/GLTFUtility.git Assets/Submodules/GLTFUtility`
-    * (package) If using Unity 2018.3 or later, you can add a new entry to the manifest.json file in your Packages folder
-  `"com.siccity.gltfutility": "https://github.com/siccity/gltfutility.git"` [Manual](https://docs.unity3d.com/Manual/upm-git.html)
+### Limitations
+* Animations that used stepped interpolation on rotation curves can only be imported in-editor (it requires an editor-only API call).
 
-**NOTICE** This is a work in progress. Expect bugs. Current features can be tracked below:
-
-### Features
-- [x] Editor import
-- [ ] Editor export
-- [x] Runtime import API
-- [ ] Runtime export API
-- [x] Static mesh (with submeshes)
-- [x] UVs (up to 8 channels)
-- [x] Normals
-- [x] Tangents
-- [x] Vertex colors
-- [x] Materials (metallic/specular, opaque/mask/blend)
-- [x] Textures (embedded/external)
-- [x] Remote textures (during async only)
-- [x] Rig
-- [x] Animations (multiple)
-- [x] Morph targets
-- [x] Cameras
-- [ ] Lights
-- [ ] Draco compression
-- [x] Multithreading
-- [x] GLTF format
-- [x] GLB format
-
-### Runtime import API
-```cs
-// Single thread
-using Siccity.GLTFUtility;
-
-void ImportGLTF(string filepath) {
-   GameObject result = Importer.LoadFromFile(filepath);
-}
-```
-```cs
-// Multithreaded
-using Siccity.GLTFUtility;
-
-void ImportGLTFAsync(string filepath) {
-   Importer.ImportGLTFAsync(filepath, new ImportSettings(), OnFinishAsync);
-}
-
-void OnFinishAsync(GameObject result) {
-   Debug.Log("Finished importing " + result.name);
-}
-```
+### Learn More
+Visit the original [GLTFUtility](https://github.com/Siccity/GLTFUtility) repository for more information.

--- a/Scripts/Converters/QuaternionConverter.cs
+++ b/Scripts/Converters/QuaternionConverter.cs
@@ -13,15 +13,15 @@ namespace Siccity.GLTFUtility.Converters {
 			Quaternion q = (Quaternion) value;
 			writer.WriteStartArray();
 			writer.WriteValue(q.x);
-			writer.WriteValue(q.y);
+			writer.WriteValue(-q.y);
 			writer.WriteValue(-q.z);
-			writer.WriteValue(-q.w);
+			writer.WriteValue(q.w);
 			writer.WriteEndArray();
 		}
 
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) {
 			float[] floatArray = serializer.Deserialize<float[]>(reader);
-			return new Quaternion(floatArray[0], floatArray[1], -floatArray[2], -floatArray[3]);
+			return new Quaternion(floatArray[0], -floatArray[1], -floatArray[2], floatArray[3]);
 		}
 
 		public override bool CanConvert(Type objectType) {

--- a/Scripts/Converters/TranslationConverter.cs
+++ b/Scripts/Converters/TranslationConverter.cs
@@ -12,15 +12,15 @@ namespace Siccity.GLTFUtility.Converters {
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) {
 			Vector3 pos = (Vector3) value;
 			writer.WriteStartArray();
-			writer.WriteValue(pos.x);
+			writer.WriteValue(-pos.x);
 			writer.WriteValue(pos.y);
-			writer.WriteValue(-pos.z);
+			writer.WriteValue(pos.z);
 			writer.WriteEndArray();
 		}
 
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) {
 			float[] floatArray = serializer.Deserialize<float[]>(reader);
-			return new Vector3(floatArray[0], floatArray[1], -floatArray[2]);
+			return new Vector3(-floatArray[0], floatArray[1], floatArray[2]);
 		}
 
 		public override bool CanConvert(Type objectType) {

--- a/Scripts/Extensions.cs
+++ b/Scripts/Extensions.cs
@@ -24,9 +24,9 @@ namespace Siccity.GLTFUtility {
 
 		public static void UnpackTRS(this Matrix4x4 trs, ref Vector3 position, ref Quaternion rotation, ref Vector3 scale) {
 			position = trs.GetColumn(3);
-			position.z = -position.z;
+			position.x = -position.x;
 			rotation = trs.rotation;
-			rotation = new Quaternion(rotation.x, rotation.y, -rotation.z, -rotation.w);
+			rotation = new Quaternion(rotation.x, -rotation.y, -rotation.z, rotation.w);
 			scale = trs.lossyScale;
 		}
 	}

--- a/Scripts/Settings/ImportSettings.cs
+++ b/Scripts/Settings/ImportSettings.cs
@@ -11,5 +11,9 @@ namespace Siccity.GLTFUtility {
 		[FormerlySerializedAs("shaders")]
 		public ShaderSettings shaderOverrides = new ShaderSettings();
 		public bool useLegacyClips;
+
+		[Header("Custom Animation Settings")]
+		[Tooltip("Sample rate set on all imported animation clips.")]
+		public float frameRate = 24;
 	}
 }

--- a/Scripts/Settings/ImportSettings.cs
+++ b/Scripts/Settings/ImportSettings.cs
@@ -15,5 +15,8 @@ namespace Siccity.GLTFUtility {
 		[Header("Custom Animation Settings")]
 		[Tooltip("Sample rate set on all imported animation clips.")]
 		public float frameRate = 24;
+		public enum InterpolationMode { ImportFromFile = 0, CubicSpline = 1, Linear = 2, Step = 3 };
+		[Tooltip("Interpolation mode applied to all keyframe tangents. Use Import From File when mixing modes within an animation.")]
+		public InterpolationMode interpolationMode = InterpolationMode.Step;
 	}
 }

--- a/Scripts/Settings/ImportSettings.cs
+++ b/Scripts/Settings/ImportSettings.cs
@@ -18,5 +18,7 @@ namespace Siccity.GLTFUtility {
 		public enum InterpolationMode { ImportFromFile = 0, CubicSpline = 1, Linear = 2, Step = 3 };
 		[Tooltip("Interpolation mode applied to all keyframe tangents. Use Import From File when mixing modes within an animation.")]
 		public InterpolationMode interpolationMode = InterpolationMode.Step;
+		[Tooltip("When true, remove redundant keyframes from blend shape animations.")]
+		public bool compressBlendShapeKeyFrames = true;
 	}
 }

--- a/Scripts/Spec/GLTFAnimation.cs
+++ b/Scripts/Spec/GLTFAnimation.cs
@@ -4,6 +4,9 @@ using System.Linq;
 using Newtonsoft.Json;
 using UnityEngine;
 using UnityEngine.Scripting;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace Siccity.GLTFUtility {
 	// https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#animation
@@ -66,6 +69,24 @@ namespace Siccity.GLTFUtility {
 				}
 				Sampler sampler = samplers[channel.sampler];
 
+				ImportSettings.InterpolationMode GetInterpolationMode( string samplerInterpolationMode ) {
+					if( importSettings.interpolationMode == ImportSettings.InterpolationMode.ImportFromFile ) {
+						if( samplerInterpolationMode == "STEP" ) {
+							return ImportSettings.InterpolationMode.Step;
+						} else if( samplerInterpolationMode == "LINEAR" ) {
+							return ImportSettings.InterpolationMode.Linear;
+						} else if( samplerInterpolationMode == "CUBICSPLINE" ) {
+							return ImportSettings.InterpolationMode.CubicSpline;
+						} else {
+							Debug.LogWarning( $"Unsupported interpolation mode: {samplerInterpolationMode}. Defaulting to STEP." );
+							return ImportSettings.InterpolationMode.Step;
+						}
+					} else {
+						return importSettings.interpolationMode;
+					}
+				}
+				var interpolationMode = GetInterpolationMode( sampler.interpolation );
+
 				string relativePath = "";
 
 				GLTFNode.ImportResult node = nodes[channel.target.node.Value];
@@ -85,9 +106,9 @@ namespace Siccity.GLTFUtility {
 						AnimationCurve posY = new AnimationCurve();
 						AnimationCurve posZ = new AnimationCurve();
 						for (int k = 0; k < keyframeInput.Length; k++) {
-							posX.AddKey(keyframeInput[k], pos[k].x);
-							posY.AddKey(keyframeInput[k], pos[k].y);
-							posZ.AddKey(keyframeInput[k], -pos[k].z);
+							posX.AddKey( CreateKeyframe( keyframeInput[k], pos[k].x, interpolationMode ) );
+							posY.AddKey( CreateKeyframe( keyframeInput[k], pos[k].y, interpolationMode ) );
+							posZ.AddKey( CreateKeyframe( keyframeInput[k], -pos[k].z, interpolationMode ) );
 						}
 						result.clip.SetCurve(relativePath, typeof(Transform), "localPosition.x", posX);
 						result.clip.SetCurve(relativePath, typeof(Transform), "localPosition.y", posY);
@@ -95,20 +116,68 @@ namespace Siccity.GLTFUtility {
 						break;
 					case "rotation":
 						Vector4[] rot = accessors[sampler.output].ReadVec4().ToArray();
-						AnimationCurve rotX = new AnimationCurve();
-						AnimationCurve rotY = new AnimationCurve();
-						AnimationCurve rotZ = new AnimationCurve();
-						AnimationCurve rotW = new AnimationCurve();
-						for (int k = 0; k < keyframeInput.Length; k++) {
-							rotX.AddKey(keyframeInput[k], rot[k].x);
-							rotY.AddKey(keyframeInput[k], rot[k].y);
-							rotZ.AddKey(keyframeInput[k], -rot[k].z);
-							rotW.AddKey(keyframeInput[k], -rot[k].w);
+
+						bool willProcessSteppedKeyframes = interpolationMode == ImportSettings.InterpolationMode.Step && Application.isEditor && !Application.isPlaying;
+
+						// @HACK: Creating stepped tangent keyframes is only supported in-editor -- not at runtime (Unity API restriction)
+						#if UNITY_EDITOR // 🤢🤮
+						if( willProcessSteppedKeyframes ) {
+							AnimationCurve rotX = new AnimationCurve();
+							AnimationCurve rotY = new AnimationCurve();
+							AnimationCurve rotZ = new AnimationCurve();
+							for (int k = 0; k < keyframeInput.Length; k++) {
+								Vector3 eulerRotation = new Quaternion( rot[ k ].x, rot[ k ].y, -rot[ k ].z, -rot[ k ].w ).eulerAngles;
+
+								rotX.AddKey( CreateKeyframe( keyframeInput[ k ], eulerRotation.x, interpolationMode ) );
+								rotY.AddKey( CreateKeyframe( keyframeInput[ k ], eulerRotation.y, interpolationMode ) );
+								rotZ.AddKey( CreateKeyframe( keyframeInput[ k ], eulerRotation.z, interpolationMode ) );
+							}
+
+							EditorCurveBinding GetEditorBinding( string property ) {
+								return EditorCurveBinding.DiscreteCurve( relativePath, typeof( Transform ), property );
+							}
+
+							// Null out any other euler rotation curves on this clip, just to be safe.
+							// https://forum.unity.com/threads/new-animationclip-property-names.367288/#post-2384172
+							AnimationUtility.SetEditorCurve( result.clip, GetEditorBinding( "localEulerAngles.x" ), null );
+							AnimationUtility.SetEditorCurve( result.clip, GetEditorBinding( "localEulerAngles.y" ), null );
+							AnimationUtility.SetEditorCurve( result.clip, GetEditorBinding( "localEulerAngles.z" ), null );
+							AnimationUtility.SetEditorCurve( result.clip, GetEditorBinding( "m_LocalEulerAngles.x" ), null );
+							AnimationUtility.SetEditorCurve( result.clip, GetEditorBinding( "m_LocalEulerAngles.y" ), null );
+							AnimationUtility.SetEditorCurve( result.clip, GetEditorBinding( "m_LocalEulerAngles.z" ), null );
+
+							AnimationUtility.SetEditorCurve( result.clip, GetEditorBinding( "localEulerAnglesBaked.x" ), null );
+							AnimationUtility.SetEditorCurve( result.clip, GetEditorBinding( "localEulerAnglesBaked.y" ), null );
+							AnimationUtility.SetEditorCurve( result.clip, GetEditorBinding( "localEulerAnglesBaked.z" ), null );
+							AnimationUtility.SetEditorCurve( result.clip, GetEditorBinding( "m_LocalEulerAnglesBaked.x" ), null );
+							AnimationUtility.SetEditorCurve( result.clip, GetEditorBinding( "m_LocalEulerAnglesBaked.y" ), null );
+							AnimationUtility.SetEditorCurve( result.clip, GetEditorBinding( "m_LocalEulerAnglesBaked.z" ), null );
+
+
+							AnimationUtility.SetEditorCurve( result.clip, GetEditorBinding( "localEulerAnglesRaw.x" ), rotX );
+							AnimationUtility.SetEditorCurve( result.clip, GetEditorBinding( "localEulerAnglesRaw.y" ), rotY );
+							AnimationUtility.SetEditorCurve( result.clip, GetEditorBinding( "localEulerAnglesRaw.z" ), rotZ );
 						}
-						result.clip.SetCurve(relativePath, typeof(Transform), "localRotation.x", rotX);
-						result.clip.SetCurve(relativePath, typeof(Transform), "localRotation.y", rotY);
-						result.clip.SetCurve(relativePath, typeof(Transform), "localRotation.z", rotZ);
-						result.clip.SetCurve(relativePath, typeof(Transform), "localRotation.w", rotW);
+						#endif
+
+						if( !willProcessSteppedKeyframes ) {
+							AnimationCurve rotX = new AnimationCurve();
+							AnimationCurve rotY = new AnimationCurve();
+							AnimationCurve rotZ = new AnimationCurve();
+							AnimationCurve rotW = new AnimationCurve();
+							for (int k = 0; k < keyframeInput.Length; k++) {
+								rotX.AddKey( CreateKeyframe( keyframeInput[k], rot[k].x, interpolationMode ) );
+								rotY.AddKey( CreateKeyframe( keyframeInput[k], rot[k].y, interpolationMode ) );
+								rotZ.AddKey( CreateKeyframe( keyframeInput[k], -rot[k].z, interpolationMode ) );
+								rotW.AddKey( CreateKeyframe( keyframeInput[k], -rot[k].w, interpolationMode ) );
+							}
+
+							result.clip.SetCurve(relativePath, typeof(Transform), "localRotation.x", rotX);
+							result.clip.SetCurve(relativePath, typeof(Transform), "localRotation.y", rotY);
+							result.clip.SetCurve(relativePath, typeof(Transform), "localRotation.z", rotZ);
+							result.clip.SetCurve(relativePath, typeof(Transform), "localRotation.w", rotW);
+						}
+
 						break;
 					case "scale":
 						Vector3[] scale = accessors[sampler.output].ReadVec3().ToArray();
@@ -116,9 +185,9 @@ namespace Siccity.GLTFUtility {
 						AnimationCurve scaleY = new AnimationCurve();
 						AnimationCurve scaleZ = new AnimationCurve();
 						for (int k = 0; k < keyframeInput.Length; k++) {
-							scaleX.AddKey(keyframeInput[k], scale[k].x);
-							scaleY.AddKey(keyframeInput[k], scale[k].y);
-							scaleZ.AddKey(keyframeInput[k], scale[k].z);
+							scaleX.AddKey( CreateKeyframe( keyframeInput[k], scale[k].x, interpolationMode ) );
+							scaleY.AddKey( CreateKeyframe( keyframeInput[k], scale[k].y, interpolationMode ) );
+							scaleZ.AddKey( CreateKeyframe( keyframeInput[k], scale[k].z, interpolationMode ) );
 						}
 						result.clip.SetCurve(relativePath, typeof(Transform), "localScale.x", scaleX);
 						result.clip.SetCurve(relativePath, typeof(Transform), "localScale.y", scaleY);
@@ -130,6 +199,45 @@ namespace Siccity.GLTFUtility {
 				}
 			}
 			return result;
+		}
+
+		public static Keyframe CreateKeyframe( float time, float value, ImportSettings.InterpolationMode interpolationMode ) {
+			float inTangent = 0;
+			float outTangent = 0;
+			float inWeight = 0;
+			float outWeight = 0;
+			WeightedMode weightedMode = WeightedMode.None;
+			bool isKeyBroken = false;
+
+			if( interpolationMode == ImportSettings.InterpolationMode.Step ) {
+				inTangent = float.PositiveInfinity;
+				inWeight = 1;
+				outTangent = float.PositiveInfinity;
+				outWeight = 1;
+				weightedMode = WeightedMode.Both;
+				isKeyBroken = true;
+			} else if( interpolationMode == ImportSettings.InterpolationMode.CubicSpline ) {
+				// @TODO: Find out what the right math is to calculate the tangent/weight values.
+				// For now, just let Unity do whatever it does by default :)
+				return new Keyframe( time, value );
+			} else if( interpolationMode == ImportSettings.InterpolationMode.Linear ) {
+				inTangent = 0;
+				inWeight = 0;
+				outTangent = 0;
+				outWeight = 0;
+				weightedMode = WeightedMode.Both;
+				isKeyBroken = true;
+			}
+
+			Keyframe keyframe = new Keyframe( time, value, inTangent, outTangent, inWeight, outWeight );
+			keyframe.weightedMode = weightedMode;
+			if( isKeyBroken ) {
+				#pragma warning disable CS0618
+				// https://github.com/unity-cn/CustomAnimationTools/blob/0b3b340c0880452949c34355052d9efb02990d4b/AnimationTools/Assets/Editor/CustomAnimationTools.cs#L164
+				keyframe.tangentMode |= ( 1 << 0 );
+				#pragma warning restore CS0618
+			}
+			return keyframe;
 		}
 	}
 

--- a/Scripts/Spec/GLTFAnimation.cs
+++ b/Scripts/Spec/GLTFAnimation.cs
@@ -52,6 +52,7 @@ namespace Siccity.GLTFUtility {
 			ImportResult result = new ImportResult();
 			result.clip = new AnimationClip();
 			result.clip.name = name;
+			result.clip.frameRate = importSettings.frameRate;
 
 			if (importSettings.useLegacyClips) {
 				result.clip.legacy = true;

--- a/Scripts/Spec/GLTFAnimation.cs
+++ b/Scripts/Spec/GLTFAnimation.cs
@@ -205,6 +205,8 @@ namespace Siccity.GLTFUtility {
 
 						float[] weights = accessors[ sampler.output ].ReadFloat().ToArray();
 
+						float[] previouslyKeyedValues = new float[ numberOfBlendShapes ];
+
 						// Reference for my future self:
 						// keyframeInput.Length = number of keyframes
 						// keyframeInput[ k ] = timestamp of keyframe
@@ -218,6 +220,15 @@ namespace Siccity.GLTFUtility {
 								float weightValue = weights[ weightIndex ];
 
 								bool addKey = true;
+								if( importSettings.compressBlendShapeKeyFrames ) {
+									if( k == 0 || !Mathf.Approximately( weightValue, previouslyKeyedValues[ j ] ) ) {
+										previouslyKeyedValues[ j ] = weightValue;
+										addKey = true;
+									} else {
+										addKey = false;
+									}
+								}
+
 								if( addKey ) {
 									blendShapeCurves[ j ].AddKey( CreateKeyframe( keyframeInput[ k ], weightValue, interpolationMode ) );
 								}

--- a/Scripts/Spec/GLTFAnimation.cs
+++ b/Scripts/Spec/GLTFAnimation.cs
@@ -64,7 +64,7 @@ namespace Siccity.GLTFUtility {
 			for (int i = 0; i < channels.Length; i++) {
 				Channel channel = channels[i];
 				if (samplers.Length <= channel.sampler) {
-					Debug.LogWarning("Animation channel points to sampler at index " + channel.sampler + " which doesn't exist. Skipping animation clip.");
+					Debug.LogWarning($"GLTFUtility: Animation channel points to sampler at index {channel.sampler} which doesn't exist. Skipping animation clip.");
 					continue;
 				}
 				Sampler sampler = samplers[channel.sampler];
@@ -106,9 +106,9 @@ namespace Siccity.GLTFUtility {
 						AnimationCurve posY = new AnimationCurve();
 						AnimationCurve posZ = new AnimationCurve();
 						for (int k = 0; k < keyframeInput.Length; k++) {
-							posX.AddKey( CreateKeyframe( keyframeInput[k], pos[k].x, interpolationMode ) );
+							posX.AddKey( CreateKeyframe( keyframeInput[k], -pos[k].x, interpolationMode ) );
 							posY.AddKey( CreateKeyframe( keyframeInput[k], pos[k].y, interpolationMode ) );
-							posZ.AddKey( CreateKeyframe( keyframeInput[k], -pos[k].z, interpolationMode ) );
+							posZ.AddKey( CreateKeyframe( keyframeInput[k], pos[k].z, interpolationMode ) );
 						}
 						result.clip.SetCurve(relativePath, typeof(Transform), "localPosition.x", posX);
 						result.clip.SetCurve(relativePath, typeof(Transform), "localPosition.y", posY);
@@ -120,13 +120,13 @@ namespace Siccity.GLTFUtility {
 						bool willProcessSteppedKeyframes = interpolationMode == ImportSettings.InterpolationMode.Step && Application.isEditor && !Application.isPlaying;
 
 						// @HACK: Creating stepped tangent keyframes is only supported in-editor -- not at runtime (Unity API restriction)
-						#if UNITY_EDITOR // 🤢🤮
+						#if UNITY_EDITOR // 🤢🤮💔
 						if( willProcessSteppedKeyframes ) {
 							AnimationCurve rotX = new AnimationCurve();
 							AnimationCurve rotY = new AnimationCurve();
 							AnimationCurve rotZ = new AnimationCurve();
 							for (int k = 0; k < keyframeInput.Length; k++) {
-								Vector3 eulerRotation = new Quaternion( rot[ k ].x, rot[ k ].y, -rot[ k ].z, -rot[ k ].w ).eulerAngles;
+								Vector3 eulerRotation = new Quaternion( rot[ k ].x, -rot[ k ].y, -rot[ k ].z, rot[ k ].w ).eulerAngles;
 
 								rotX.AddKey( CreateKeyframe( keyframeInput[ k ], eulerRotation.x, interpolationMode ) );
 								rotY.AddKey( CreateKeyframe( keyframeInput[ k ], eulerRotation.y, interpolationMode ) );
@@ -167,9 +167,9 @@ namespace Siccity.GLTFUtility {
 							AnimationCurve rotW = new AnimationCurve();
 							for (int k = 0; k < keyframeInput.Length; k++) {
 								rotX.AddKey( CreateKeyframe( keyframeInput[k], rot[k].x, interpolationMode ) );
-								rotY.AddKey( CreateKeyframe( keyframeInput[k], rot[k].y, interpolationMode ) );
+								rotY.AddKey( CreateKeyframe( keyframeInput[k], -rot[k].y, interpolationMode ) );
 								rotZ.AddKey( CreateKeyframe( keyframeInput[k], -rot[k].z, interpolationMode ) );
-								rotW.AddKey( CreateKeyframe( keyframeInput[k], -rot[k].w, interpolationMode ) );
+								rotW.AddKey( CreateKeyframe( keyframeInput[k], rot[k].w, interpolationMode ) );
 							}
 
 							result.clip.SetCurve(relativePath, typeof(Transform), "localRotation.x", rotX);

--- a/Scripts/Spec/GLTFBuffer.cs
+++ b/Scripts/Spec/GLTFBuffer.cs
@@ -35,7 +35,7 @@ namespace Siccity.GLTFUtility {
 			if (uri == null) {
 				// Load entire file
 				if (string.IsNullOrEmpty(filepath)) result.stream = new MemoryStream(bytefile);
-				else result.stream = File.Open(filepath, FileMode.Open);
+				else result.stream = File.OpenRead(filepath);
 				result.startOffset = binChunkStart + 8;
 				result.stream.Position = result.startOffset;
 			} else if (uri.StartsWith(embeddedPrefix)) {
@@ -51,7 +51,7 @@ namespace Siccity.GLTFUtility {
 			} else {
 				// Load URI
 				string directoryRoot = Directory.GetParent(filepath).ToString() + "/";
-				result.stream = File.Open(directoryRoot + uri, FileMode.Open);
+				result.stream = File.OpenRead(directoryRoot + uri);
 				result.startOffset = result.stream.Length - byteLength;
 			}
 

--- a/Scripts/Spec/GLTFMesh.cs
+++ b/Scripts/Spec/GLTFMesh.cs
@@ -69,9 +69,9 @@ namespace Siccity.GLTFUtility {
 							int vertStartIndex = verts.Count;
 							submeshVertexStart.Add(vertStartIndex);
 
-							// Verts - (Z points backwards in GLTF)
+							// Verts - (X points left in GLTF)
 							if (primitive.attributes.POSITION.HasValue) {
-								IEnumerable<Vector3> newVerts = accessors[primitive.attributes.POSITION.Value].ReadVec3().Select(v => { v.z = -v.z; return v; });
+								IEnumerable<Vector3> newVerts = accessors[primitive.attributes.POSITION.Value].ReadVec3().Select(v => { v.x = -v.x; return v; });
 								verts.AddRange(newVerts);
 							}
 
@@ -83,14 +83,14 @@ namespace Siccity.GLTFUtility {
 								submeshTrisMode.Add(primitive.mode);
 							}
 
-							/// Normals - (Z points backwards in GLTF)
+							/// Normals - (X points left in GLTF)
 							if (primitive.attributes.NORMAL.HasValue) {
-								normals.AddRange(accessors[primitive.attributes.NORMAL.Value].ReadVec3().Select(v => { v.z = -v.z; return v; }));
+								normals.AddRange(accessors[primitive.attributes.NORMAL.Value].ReadVec3().Select(v => { v.x = -v.x; return v; }));
 							}
 
-							// Tangents - (Z points backwards in GLTF)
+							// Tangents - (X points left in GLTF)
 							if (primitive.attributes.TANGENT.HasValue) {
-								tangents.AddRange(accessors[primitive.attributes.TANGENT.Value].ReadVec4().Select(v => { v.z = -v.z; v.w = -v.w; return v; }));
+								tangents.AddRange(accessors[primitive.attributes.TANGENT.Value].ReadVec4().Select(v => { v.y = -v.y; v.z = -v.z; return v; }));
 							}
 
 							// Vertex colors
@@ -166,7 +166,7 @@ namespace Siccity.GLTFUtility {
 							Debug.LogWarning("Accessor is null");
 							return new Vector3[vertCount];
 						}
-						Vector3[] accessorData = accessors[accessor.Value].ReadVec3().Select(v => { v.z = -v.z; return v; }).ToArray();
+						Vector3[] accessorData = accessors[accessor.Value].ReadVec3().Select(v => { v.x = -v.x; return v; }).ToArray();
 						if (accessorData.Length != vertCount) {
 							Vector3[] resized = new Vector3[vertCount];
 							Array.Copy(accessorData, 0, resized, vertStartIndex, accessorData.Length);

--- a/Scripts/Spec/GLTFObject.cs
+++ b/Scripts/Spec/GLTFObject.cs
@@ -20,7 +20,7 @@ namespace Siccity.GLTFUtility {
 		public List<GLTFImage> images;
 		public List<GLTFMaterial> materials;
 		public List<GLTFCamera> cameras;
-		//public List<string> extensionsUsed; not supported yet
-		//public List<string> extensionsRequired; not supported yet
+		public List<string> extensionsUsed;
+		public List<string> extensionsRequired;
 	}
 }

--- a/Scripts/Spec/GLTFSkin.cs
+++ b/Scripts/Spec/GLTFSkin.cs
@@ -62,17 +62,22 @@ namespace Siccity.GLTFUtility {
 			if (inverseBindMatrices.HasValue) {
 				result.inverseBindMatrices = accessors[inverseBindMatrices.Value].ReadMatrix4x4();
 				for (int i = 0; i < result.inverseBindMatrices.Length; i++) {
-					// Flip the matrix from GLTF to Unity format. This was done through trial and error, i can't explain it.
+					// Flip the matrix from GLTF to Unity format.
+					// This was done through comparing the GLTF matrix to
+					// the correctly imported matrix from the source model,
+					// and flipping the values where needed.
+					// Notice how the rows become collumns
 					Matrix4x4 m = result.inverseBindMatrices[i];
+
 					Vector4 row0 = m.GetRow(0);
+					row0.y = -row0.y;
 					row0.z = -row0.z;
 					Vector4 row1 = m.GetRow(1);
-					row1.z = -row1.z;
+					row1.x = -row1.x;
 					Vector4 row2 = m.GetRow(2);
 					row2.x = -row2.x;
-					row2.y = -row2.y;
 					Vector4 row3 = m.GetRow(3);
-					row3.z = -row3.z;
+					row3.x = -row3.x;
 					m.SetColumn(0, row0);
 					m.SetColumn(1, row1);
 					m.SetColumn(2, row2);

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
     "version": "0.6.0",
     "unity": "2018.2",
     "keywords": ["glTF", "import"],
-    "description": "Lightweight glTF loader."
+    "description": "Lightweight glTF loader.",
+    "dependencies": {
+        "com.unity.nuget.newtonsoft-json": "2.0.0-preview"
+    }
 }


### PR DESCRIPTION
@sprylyltd and I have been adding some features to your wonderful utility 💜, and we hope you find these helpful to integrate on yours too 🧠:

- Animate blend shapes.

> Implements a way to add Blend Shapes/Key Shapes authored in blender, and bring them in as animation clips, which is very useful for animation, such as adding corrective blend shapes, or doing blend shape driven animation.

- Animate with stepped and linear interpolation modes.

> Imports animation with interpolation as close as possible as it was in blender (a fix for non - interpolated animation to work properly on Unity).

- Force animations to use a specific interpolation mode.

> Options to force all keyframes to be a specific interpolation mode _ie all keys set to constant, to show blocking work_

- Cut out redundant blend shape animation key frames.

> When importing blend shapes, it created a lot of garbage frames, so this feature, helps compress those animation clips, and lets us keep only the necessary keyframes 🤓.

- Set a custom frame rate on imported animation clips.

> Lets user pick a frame rate on import, which gives the ability to stay consistent to whatever frame rate we used to author the animation in Blender.

- Don't worry about installing package dependencies.

> Json dependency is included on the package

Here's a screenshot of some of the features added on the Editor:

<img width="371" alt="Screen Shot 2020-05-06 at 9 59 26 AM" src="https://user-images.githubusercontent.com/20521814/81206174-9533b080-8f80-11ea-8c84-9c14d69224fe.png">