### PR TITLE
Propagate byteStride to accessor.

### DIFF
--- a/Scripts/Spec/GLTFAccessor.cs
+++ b/Scripts/Spec/GLTFAccessor.cs
@@ -444,6 +444,7 @@ namespace Siccity.GLTFUtility {
 			result.type = type;
 			result.count = count;
 			result.byteOffset = byteOffset;
+			result.byteStride = result.bufferView != null ? result.bufferView.byteStride : null;
 			// Sparse accessor works by overwriting specified indices instead of defining a full data set. This can save space, especially for morph targets
 			if (sparse != null) {
 				result.sparse = new ImportResult.Sparse() {


### PR DESCRIPTION
If I'm not mistaken, the `byteStride` attribute should be propagated from the BufferViews to their accessors, otherwise reading a model file that defines a stride will result in a mess.

An example for this would be this Avocado:
https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Avocado/glTF-Quantized