### PR TITLE
Fix: ScriptedImporter is out of Experimental starting with 2020.2

### DIFF
--- a/Scripts/Editor/GLBImporter.cs
+++ b/Scripts/Editor/GLBImporter.cs
@@ -1,5 +1,9 @@
-﻿using UnityEditor.Experimental.AssetImporters;
 using UnityEngine;
+#if !UNITY_2020_2_OR_NEWER
+using UnityEditor.Experimental.AssetImporters;
+#else
+using UnityEditor.AssetImporters;
+#endif
 
 namespace Siccity.GLTFUtility {
 	[ScriptedImporter(1, "glb")]

--- a/Scripts/Editor/GLTFAssetUtility.cs
+++ b/Scripts/Editor/GLTFAssetUtility.cs
@@ -1,7 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
+#if !UNITY_2020_2_OR_NEWER
 using UnityEditor.Experimental.AssetImporters;
+#else
+using UnityEditor.AssetImporters;
+#endif
 using UnityEngine;
 
 namespace Siccity.GLTFUtility {

--- a/Scripts/Editor/GLTFImporter.cs
+++ b/Scripts/Editor/GLTFImporter.cs
@@ -1,5 +1,9 @@
 ﻿using UnityEditor;
+#if !UNITY_2020_2_OR_NEWER
 using UnityEditor.Experimental.AssetImporters;
+#else
+using UnityEditor.AssetImporters;
+#endif
 using UnityEngine;
 
 namespace Siccity.GLTFUtility {


### PR DESCRIPTION
This adds proper ifdefs to support Unity 2020.2+.