### PR TITLE
More lightmap unwrapping options

### DIFF
--- a/Scripts/Editor/GLTFAssetUtility.cs
+++ b/Scripts/Editor/GLTFAssetUtility.cs
@@ -18,19 +18,27 @@ namespace Siccity.GLTFUtility {
 #else
 			ctx.SetMainAsset("main obj", root);
 #endif
+			UnwrapParam? unwrapParams = new UnwrapParam()
+			{
+				angleError = settings.angleError,
+				areaError = settings.areaError,
+				hardAngle = settings.hardAngle,
+				packMargin = settings.packMargin
+			};
+
 			MeshRenderer[] renderers = root.GetComponentsInChildren<MeshRenderer>(true);
 			SkinnedMeshRenderer[] skinnedRenderers = root.GetComponentsInChildren<SkinnedMeshRenderer>(true);
 			MeshFilter[] filters = root.GetComponentsInChildren<MeshFilter>(true);
-			AddMeshes(filters, skinnedRenderers, ctx, settings.generateLightmapUVs);
+			AddMeshes(filters, skinnedRenderers, ctx, settings.generateLightmapUVs ? unwrapParams : null);
 			AddMaterials(renderers, skinnedRenderers, ctx);
 			AddAnimations(animations, ctx, settings.animationSettings);
 		}
 
-		public static void AddMeshes(MeshFilter[] filters, SkinnedMeshRenderer[] skinnedRenderers, AssetImportContext ctx, bool generateLightmapUVs) {
+		public static void AddMeshes(MeshFilter[] filters, SkinnedMeshRenderer[] skinnedRenderers, AssetImportContext ctx, UnwrapParam? lightmapUnwrapInfo) {
 			HashSet<Mesh> visitedMeshes = new HashSet<Mesh>();
 			for (int i = 0; i < filters.Length; i++) {
 				Mesh mesh = filters[i].sharedMesh;
-				if (generateLightmapUVs) Unwrapping.GenerateSecondaryUVSet(mesh);
+				if (lightmapUnwrapInfo.HasValue) Unwrapping.GenerateSecondaryUVSet(mesh, lightmapUnwrapInfo.Value);
 				if (visitedMeshes.Contains(mesh)) continue;
 				ctx.AddAsset(mesh.name, mesh);
 				visitedMeshes.Add(mesh);

--- a/Scripts/Settings/ImportSettings.cs
+++ b/Scripts/Settings/ImportSettings.cs
@@ -14,6 +14,17 @@ namespace Siccity.GLTFUtility {
 		public AnimationSettings animationSettings = new AnimationSettings();
 		public bool useLegacyClips;
 		public bool generateLightmapUVs;
+		[Range(0, 180)]
+		public float hardAngle = 88;
+
+		[Range(1, 75)]
+		public float angleError = 8;
+
+		[Range(1, 75)]
+		public float areaError = 15;
+
+		[Range(1, 64)]
+		public float packMargin = 4;
 
 		[Tooltip("Interpolation mode applied to all keyframe tangents. Use Import From File when mixing modes within an animation.")]
 		public InterpolationMode interpolationMode = InterpolationMode.ImportFromFile;

--- a/Scripts/Spec/GLTFAccessor.cs
+++ b/Scripts/Spec/GLTFAccessor.cs
@@ -44,6 +44,13 @@ namespace Siccity.GLTFUtility {
 
 #region Import
 		public class ImportResult {
+
+			private const float byteNormalize = 1f / byte.MaxValue;
+			private const float shortNormalize = 1f / short.MaxValue;
+			private const float ushortNormalize = 1f / ushort.MaxValue;
+			private const float intNormalize = 1f / int.MaxValue;
+			private const float uintNormalize = 1f / uint.MaxValue;
+
 			public GLTFBufferView.ImportResult bufferView;
 			public int? byteStride;
 			public int count;
@@ -132,10 +139,10 @@ namespace Siccity.GLTFUtility {
 				return m;
 			}
 
-			public Vector4[] ReadVec4() {
+			public Vector4[] ReadVec4(bool normalize = false) {
 				if (!ValidateAccessorType(type, AccessorType.VEC4)) return new Vector4[count];
 
-				Func<BufferedBinaryReader, float> floatReader = GetFloatReader(componentType);
+				Func<BufferedBinaryReader, float> floatReader = normalize ? GetNormalizedFloatReader(componentType) : GetFloatReader(componentType);
 
 				Vector4[] v = new Vector4[count];
 				if (bufferView != null) {
@@ -174,7 +181,7 @@ namespace Siccity.GLTFUtility {
 			public Color[] ReadColor() {
 				if (!ValidateAccessorTypeAny(type, AccessorType.VEC3, AccessorType.VEC4)) return new Color[count];
 
-				Func<BufferedBinaryReader, float> floatReader = GetFloatReader(componentType);
+				Func<BufferedBinaryReader, float> floatReader = GetNormalizedFloatReader(componentType);
 
 				Color[] c = new Color[count];
 				if (bufferView != null) {
@@ -268,7 +275,7 @@ namespace Siccity.GLTFUtility {
 			public Vector2[] ReadVec2() {
 				if (!ValidateAccessorType(type, AccessorType.VEC2)) return new Vector2[count];
 
-				Func<BufferedBinaryReader, float> floatReader = GetFloatReader(componentType);
+				Func<BufferedBinaryReader, float> floatReader = GetNormalizedFloatReader(componentType);
 
 				Vector2[] v = new Vector2[count];
 				if (bufferView != null) {
@@ -402,6 +409,29 @@ namespace Siccity.GLTFUtility {
 						return readMethod = x => x.ReadUInt16();
 					case GLType.UNSIGNED_INT:
 						return readMethod = x => x.ReadUInt32();
+					default:
+						Debug.LogWarning("No componentType defined");
+						return readMethod = x => x.ReadSingle();
+				}
+			}
+
+			public Func<BufferedBinaryReader, float> GetNormalizedFloatReader(GLType componentType)
+			{
+				Func<BufferedBinaryReader, float> readMethod;
+				switch(componentType)
+				{
+					case GLType.BYTE:
+						return x => x.ReadSByte();
+					case GLType.UNSIGNED_BYTE:
+						return readMethod = x => x.ReadByte() * byteNormalize;
+					case GLType.FLOAT:
+						return readMethod = x => x.ReadSingle();
+					case GLType.SHORT:
+						return readMethod = x => x.ReadInt16() * shortNormalize;
+					case GLType.UNSIGNED_SHORT:
+						return readMethod = x => x.ReadUInt16() * ushortNormalize;
+					case GLType.UNSIGNED_INT:
+						return readMethod = x => x.ReadUInt32() / uintNormalize;
 					default:
 						Debug.LogWarning("No componentType defined");
 						return readMethod = x => x.ReadSingle();

--- a/Scripts/Spec/GLTFImage.cs
+++ b/Scripts/Spec/GLTFImage.cs
@@ -58,10 +58,15 @@ namespace Siccity.GLTFUtility {
 							}
 							yield return null;
 						}
-
 						if (onProgress != null) onProgress(1f);
-
-						if (uwr.isNetworkError || uwr.isHttpError) {
+						
+#if UNITY_2020_2_OR_NEWER
+						if(uwr.result == UnityWebRequest.Result.ConnectionError ||
+							uwr.result == UnityWebRequest.Result.ProtocolError)
+#else
+						if(uwr.isNetworkError || uwr.isHttpError)
+#endif
+						{ 
 							Debug.LogError("GLTFImage.cs ToTexture2D() ERROR: " + uwr.error);
 						} else {
 							Texture2D tex = DownloadHandlerTexture.GetContent(uwr);

--- a/Scripts/Spec/GLTFMesh.cs
+++ b/Scripts/Spec/GLTFMesh.cs
@@ -160,7 +160,7 @@ namespace Siccity.GLTFUtility {
 
 								// Weights
 								if (primitive.attributes.WEIGHTS_0.HasValue && primitive.attributes.JOINTS_0.HasValue) {
-									Vector4[] weights0 = accessors[primitive.attributes.WEIGHTS_0.Value].ReadVec4();
+									Vector4[] weights0 = accessors[primitive.attributes.WEIGHTS_0.Value].ReadVec4(true);
 									Vector4[] joints0 = accessors[primitive.attributes.JOINTS_0.Value].ReadVec4();
 									if (joints0.Length == weights0.Length) {
 										BoneWeight[] boneWeights = new BoneWeight[weights0.Length];


### PR DESCRIPTION
- Added more lightmap unwrapping options (the unwrap parameters used in built-in mesh importers)
- Replaced unity web request result check for unity 2020.2 and newer (old variant deprecated)