### PR TITLE
Add morph target/blendshape animation support

### DIFF
--- a/Scripts/Converters/Vector2Converter.cs
+++ b/Scripts/Converters/Vector2Converter.cs
@@ -18,7 +18,7 @@ namespace Siccity.GLTFUtility.Converters {
 			float[] floatArray = null;
 			try {
 				floatArray = serializer.Deserialize<float[]>(reader);
-			} catch (System.Exception e) {
+			} catch (System.Exception) {
 				floatArray = new float[] { serializer.Deserialize<float>(reader) };
 			}
 

--- a/Scripts/Settings/AnimationSettings.cs
+++ b/Scripts/Settings/AnimationSettings.cs
@@ -7,5 +7,13 @@ namespace Siccity.GLTFUtility {
 	[Serializable]
 	public class AnimationSettings {
 		public bool looping;
+		[Tooltip("Sample rate set on all imported animation clips.")]
+		public float frameRate = 24;
+		[Tooltip("Interpolation mode applied to all keyframe tangents. Use Import From File when mixing modes within an animation.")]
+		public InterpolationMode interpolationMode = InterpolationMode.ImportFromFile;
+		[Tooltip("When true, remove redundant keyframes from blend shape animations.")]
+		public bool compressBlendShapeKeyFrames = true;
+		[Tooltip("Load animations as legacy AnimationClips.")]
+		public bool useLegacyClips;
 	}
 }

--- a/Scripts/Settings/ImportSettings.cs
+++ b/Scripts/Settings/ImportSettings.cs
@@ -26,7 +26,11 @@ namespace Siccity.GLTFUtility {
 		[Range(1, 64)]
 		public float packMargin = 4;
 
+		[Tooltip("Sample rate set on all imported animation clips.")]
+		public float frameRate = 24;
 		[Tooltip("Interpolation mode applied to all keyframe tangents. Use Import From File when mixing modes within an animation.")]
 		public InterpolationMode interpolationMode = InterpolationMode.ImportFromFile;
+		[Tooltip("When true, remove redundant keyframes from blend shape animations.")]
+		public bool compressBlendShapeKeyFrames = true;
 	}
 }

--- a/Scripts/Settings/ImportSettings.cs
+++ b/Scripts/Settings/ImportSettings.cs
@@ -12,7 +12,6 @@ namespace Siccity.GLTFUtility {
 		[FormerlySerializedAs("shaders")]
 		public ShaderSettings shaderOverrides = new ShaderSettings();
 		public AnimationSettings animationSettings = new AnimationSettings();
-		public bool useLegacyClips;
 		public bool generateLightmapUVs;
 		[Range(0, 180)]
 		public float hardAngle = 88;

--- a/Scripts/Settings/ImportSettings.cs
+++ b/Scripts/Settings/ImportSettings.cs
@@ -25,11 +25,5 @@ namespace Siccity.GLTFUtility {
 		[Range(1, 64)]
 		public float packMargin = 4;
 
-		[Tooltip("Sample rate set on all imported animation clips.")]
-		public float frameRate = 24;
-		[Tooltip("Interpolation mode applied to all keyframe tangents. Use Import From File when mixing modes within an animation.")]
-		public InterpolationMode interpolationMode = InterpolationMode.ImportFromFile;
-		[Tooltip("When true, remove redundant keyframes from blend shape animations.")]
-		public bool compressBlendShapeKeyFrames = true;
 	}
 }

--- a/Scripts/Spec/GLTFAnimation.cs
+++ b/Scripts/Spec/GLTFAnimation.cs
@@ -55,7 +55,7 @@ namespace Siccity.GLTFUtility {
 			ImportResult result = new ImportResult();
 			result.clip = new AnimationClip();
 			result.clip.name = name;
-			result.clip.frameRate = importSettings.frameRate;
+			result.clip.frameRate = importSettings.animationSettings.frameRate;
 
 			result.clip.legacy = importSettings.animationSettings.useLegacyClips;
 
@@ -73,7 +73,7 @@ namespace Siccity.GLTFUtility {
 				Sampler sampler = samplers[channel.sampler];
 
 				// Get interpolation mode
-				InterpolationMode interpolationMode = importSettings.interpolationMode;
+				InterpolationMode interpolationMode = importSettings.animationSettings.interpolationMode;
 				if (interpolationMode == InterpolationMode.ImportFromFile) {
 					interpolationMode = sampler.interpolation;
 				}
@@ -172,7 +172,7 @@ namespace Siccity.GLTFUtility {
 								weightValues[k] = weights[weightIndex];
 
 								bool addKey = true;
-								if(importSettings.compressBlendShapeKeyFrames) {
+								if(importSettings.animationSettings.compressBlendShapeKeyFrames) {
 									if(k == 0 || !Mathf.Approximately(weightValues[k], previouslyKeyedValues[j])) {
 										if(k > 0) {
 											weightValues[k-1] = previouslyKeyedValues[j];

--- a/Scripts/Spec/GLTFAnimation.cs
+++ b/Scripts/Spec/GLTFAnimation.cs
@@ -140,7 +140,6 @@ namespace Siccity.GLTFUtility {
 						result.clip.SetCurve(relativePath, typeof(Transform), "localScale.z", scaleZ);
 						break;
 					case "weights":
-						//Debug.LogWarning("GLTFUtility: Morph weights in animation is not supported");
 						GLTFNode.ImportResult skinnedMeshNode = nodes[channel.target.node.Value];
 						SkinnedMeshRenderer skinnedMeshRenderer = skinnedMeshNode.transform.GetComponent<SkinnedMeshRenderer>();
 
@@ -170,8 +169,12 @@ namespace Siccity.GLTFUtility {
 								bool addKey = true;
 								if(importSettings.compressBlendShapeKeyFrames) {
 									if(k == 0 || !Mathf.Approximately(weightValues[k], previouslyKeyedValues[j])) {
-										previouslyKeyedValues[j] = weightValues[k];
+										if(k > 0) {
+											weightValues[k-1] = previouslyKeyedValues[j];
+											blendShapeCurves[j].AddKey(CreateKeyframe(k-1, keyframeInput, weightValues, x => x, interpolationMode));
+										}
 										addKey = true;
+										previouslyKeyedValues[j] = weightValues[k];
 									} else {
 										addKey = false;
 									}

--- a/Scripts/Spec/GLTFAnimation.cs
+++ b/Scripts/Spec/GLTFAnimation.cs
@@ -57,7 +57,12 @@ namespace Siccity.GLTFUtility {
 			result.clip.name = name;
 			result.clip.frameRate = importSettings.frameRate;
 
-			result.clip.legacy = importSettings.useLegacyClips;
+			result.clip.legacy = importSettings.animationSettings.useLegacyClips;
+
+			if (result.clip.legacy && importSettings.animationSettings.looping)
+			{
+				result.clip.wrapMode = WrapMode.Loop;
+			}
 
 			for (int i = 0; i < channels.Length; i++) {
 				Channel channel = channels[i];

--- a/Scripts/Spec/GLTFSkin.cs
+++ b/Scripts/Spec/GLTFSkin.cs
@@ -49,6 +49,8 @@ namespace Siccity.GLTFUtility {
 					mesh.bindposes = bindPoses;
 				}
 				smr.sharedMesh = mesh;
+				// Max 4 bones per vertex, auto-detection fails sometimes.
+				smr.quality = SkinQuality.Bone4;
 				return smr;
 			}
 		}

--- a/Scripts/Spec/GLTFSkin.cs
+++ b/Scripts/Spec/GLTFSkin.cs
@@ -49,8 +49,6 @@ namespace Siccity.GLTFUtility {
 					mesh.bindposes = bindPoses;
 				}
 				smr.sharedMesh = mesh;
-				// Max 4 bones per vertex, auto-detection fails sometimes.
-				smr.quality = SkinQuality.Bone4;
 				return smr;
 			}
 		}


### PR DESCRIPTION
Background: I recently made a bunch of changes to GLTFUtility so that the features used by Bitmoji in Unity are supported. See https://github.com/Bitmoji/GLTFUtility for details.

I thought this repo was not being maintained, but seeing as there are recent commits, I would like to contribute my changes back here.

The first is a cleanup of #76 that implements blendshape *animation* support (not just blendshapes on meshes). This would effectively close #76 as far as I understand.