### PR TITLE
Increase editor import compatibility between different glTF packages

### DIFF
--- a/Scripts/Editor/GLBImporter.cs
+++ b/Scripts/Editor/GLBImporter.cs
@@ -1,3 +1,14 @@
+#if HAVE_GLTFAST || HAVE_UNITYGLTF
+#define ANOTHER_IMPORTER_HAS_HIGHER_PRIORITY
+#endif
+
+#if !ANOTHER_IMPORTER_HAS_HIGHER_PRIORITY && !GLTFUTILITY_FORCE_DEFAULT_IMPORTER_OFF
+#define ENABLE_DEFAULT_GLB_IMPORTER
+#endif
+#if GLTFUTILITY_FORCE_DEFAULT_IMPORTER_ON
+#define ENABLE_DEFAULT_GLB_IMPORTER
+#endif
+
 using UnityEngine;
 #if !UNITY_2020_2_OR_NEWER
 using UnityEditor.Experimental.AssetImporters;
@@ -6,7 +17,11 @@ using UnityEditor.AssetImporters;
 #endif
 
 namespace Siccity.GLTFUtility {
+#if ENABLE_DEFAULT_GLB_IMPORTER
 	[ScriptedImporter(1, "glb")]
+#else
+    [ScriptedImporter(2, null, overrideExts: new[] { "glb" })]
+#endif
 	public class GLBImporter : GLTFImporter {
 
 		public override void OnImportAsset(AssetImportContext ctx) {

--- a/Scripts/Editor/GLTFImporter.cs
+++ b/Scripts/Editor/GLTFImporter.cs
@@ -1,4 +1,14 @@
-﻿using UnityEditor;
+﻿#if HAVE_GLTFAST || HAVE_UNITYGLTF
+#define ANOTHER_IMPORTER_HAS_HIGHER_PRIORITY
+#endif
+
+#if !ANOTHER_IMPORTER_HAS_HIGHER_PRIORITY && !GLTFUTILITY_FORCE_DEFAULT_IMPORTER_OFF
+#define ENABLE_DEFAULT_GLB_IMPORTER
+#endif
+#if GLTFUTILITY_FORCE_DEFAULT_IMPORTER_ON
+#define ENABLE_DEFAULT_GLB_IMPORTER
+#endif
+
 #if !UNITY_2020_2_OR_NEWER
 using UnityEditor.Experimental.AssetImporters;
 #else
@@ -7,7 +17,11 @@ using UnityEditor.AssetImporters;
 using UnityEngine;
 
 namespace Siccity.GLTFUtility {
+#if ENABLE_DEFAULT_GLB_IMPORTER
 	[ScriptedImporter(1, "gltf")]
+#else
+    [ScriptedImporter(1, null, overrideExts: new[] { "gltf" })]
+#endif
 	public class GLTFImporter : ScriptedImporter {
 
 		public ImportSettings importSettings;

--- a/Scripts/Editor/GLTFUtility.Editor.asmdef
+++ b/Scripts/Editor/GLTFUtility.Editor.asmdef
@@ -8,5 +8,17 @@
         "Editor"
     ],
     "excludePlatforms": [],
-    "allowUnsafeCode": false
+    "allowUnsafeCode": false,
+    "versionDefines": [
+        {
+            "name": "com.atteneder.gltfast",
+            "expression": "3.0.0",
+            "define": "HAVE_GLTFAST"
+        },
+        {
+            "name": "org.khronos.unitygltf",
+            "expression": "0.0.0",
+            "define": "HAVE_UNITYGLTF"
+        }
+    ]
 }


### PR DESCRIPTION
Fixes https://github.com/Siccity/GLTFUtility/issues/191

Currently, different glTF packages in the same project (e.g. UnityGLTF, glTFast, GLTFUtility) collide in terms of import: only one package must declare a ScriptedImporter ext, other packages must use overrideExt so that they can be chosen as importers.

If multiple packages declare as main importer, an error is thrown. 
This PR follows https://github.com/atteneder/glTFast/issues/352 and https://github.com/prefrontalcortex/UnityGLTF/issues/37 and introduces a pattern that resolves this problem.
Note that by default, it changes nothing - only if either of glTFast or UnityGLTF are present the importer code is adjusted.

There is now a hierarchy of package defines:
glTFast - UnityGLTF - GLTFUtility check for existance of other importers and adjust their ScriptedImporter syntax accordingly.

The default order can be changed through global scripting defines - to make GLTFUtility the default importer with all three packages in a project, one can use
`GLTFUTILITY_FORCE_DEFAULT_IMPORTER_ON`
`UNITYGLTF_FORCE_DEFAULT_IMPORTER_OFF`
`GLTFAST_FORCE_DEFAULT_IMPORTER_OFF`

With this PR, there's no error after compilation, and one can easily choose the importer via the override menu:
![image](https://user-images.githubusercontent.com/2693840/158551386-ddf18275-e8ac-44df-921b-f8d0a752b450.png)

CC @bitinn and @atteneder