### PR TITLE
Fix: duplicate GUIDs from glTFast package

### DIFF
--- a/GLTFUtility.asmdef
+++ b/GLTFUtility.asmdef
@@ -9,6 +9,10 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "Newtonsoft.Json.dll"
+    ],
     "autoReferenced": true,
     "defineConstraints": []
 }

--- a/Plugins/draco/Plugin/WSA/ARM.meta
+++ b/Plugins/draco/Plugin/WSA/ARM.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 247f211ed244a5246bd95eb03ef807bd
+guid: b159dd8376a6b774a9f07dd2f201e4e6
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Plugins/draco/Plugin/WSA/ARM/dracodec_unity.dll.meta
+++ b/Plugins/draco/Plugin/WSA/ARM/dracodec_unity.dll.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 25cda0e4b8c73b248a6cc47d8d9a5340
+guid: 3e43e0ceee9db0e4c9fbb0edfb09eb8c
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Plugins/draco/Plugin/WSA/ARM64.meta
+++ b/Plugins/draco/Plugin/WSA/ARM64.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6fd9b1242506f2242b7f0aea747d003a
+guid: c64d76d57c880a945b1c0953f7c67905
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Plugins/draco/Plugin/WSA/ARM64/dracodec_unity.dll.meta
+++ b/Plugins/draco/Plugin/WSA/ARM64/dracodec_unity.dll.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: da68c67391c543b46a4f57aa2829f479
+guid: df418818a2ee1c144b973fc03c1ae398
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Plugins/draco/Plugin/WSA/x64.meta
+++ b/Plugins/draco/Plugin/WSA/x64.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: adb1df6c7d8b745eeb059f01399eaec2
+guid: 94a09d5f74616b24a8d3bd0aeeea5669
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Plugins/draco/Plugin/WSA/x64/dracodec_unity.dll.meta
+++ b/Plugins/draco/Plugin/WSA/x64/dracodec_unity.dll.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: aa9edc03c58e1498f9df11817c09261d
+guid: a9f30f77416c79c43885db36cf0e4588
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Plugins/draco/Plugin/WSA/x86.meta
+++ b/Plugins/draco/Plugin/WSA/x86.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 55a5c1975a4d44616a048ba97f60ea08
+guid: c8d2d38fff1c0844494f0eb2f2d6d190
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Plugins/draco/Plugin/WSA/x86/dracodec_unity.dll.meta
+++ b/Plugins/draco/Plugin/WSA/x86/dracodec_unity.dll.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 22e980b26ccee44528d4c7fe7c6d781c
+guid: 531c3621fb8425f438362d7bc17f5a01
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Scripts/Editor/GLTFUtility.Editor.asmdef
+++ b/Scripts/Editor/GLTFUtility.Editor.asmdef
@@ -8,5 +8,6 @@
         "Editor"
     ],
     "excludePlatforms": [],
-    "allowUnsafeCode": false
+    "allowUnsafeCode": false,
+    "overrideReferences": true
 }


### PR DESCRIPTION
Seems some files were copied over from glTFast directly, thus causing GUID conflicts with both packages in the same project.
This PR introduces new GUIDs for these files and folders, and also makes the Newtonsoft.JSON dependency explicit.