### PR TITLE
updating from string reading to byte reading

### DIFF
--- a/Scripts/Importer.cs
+++ b/Scripts/Importer.cs
@@ -121,10 +121,9 @@ namespace Siccity.GLTFUtility {
 			// 8-[chunkLength+8] - chunkData = json data.
 			stream.Read(buffer, 0, 8);
 			uint chunkLength = System.BitConverter.ToUInt32(buffer, 0);
-			TextReader reader = new StreamReader(stream);
-			char[] jsonChars = new char[chunkLength];
-			reader.Read(jsonChars, 0, (int) chunkLength);
-			string json = new string(jsonChars);
+			byte[] jsonBytes = new byte[chunkLength];
+			stream.Read(jsonBytes, 0, (int) chunkLength);
+			string json = Encoding.Default.GetString(jsonBytes);
 
 			// Chunk
 			binChunkStart = chunkLength + 20;


### PR DESCRIPTION
When the GLB model contains Unicode character(s), getting an error `illegal characters at the end of the returned JSON`. This got fixed by changing the string reader to a byte reader.
This issue is discussed in [195](https://github.com/Siccity/GLTFUtility/issues/195)