### PR TITLE
Fixes unchecked access of primitives.targets

### DIFF
--- a/Scripts/Spec/GLTFMesh.cs
+++ b/Scripts/Spec/GLTFMesh.cs
@@ -199,7 +199,7 @@ namespace Siccity.GLTFUtility {
 
 						bool hasTargetNames = gltfMesh.extras != null && gltfMesh.extras.targetNames != null;
 						if (hasTargetNames) {
-							if (gltfMesh.primitives.All(x => x.targets.Count != gltfMesh.extras.targetNames.Length)) {
+							if (gltfMesh.primitives.All(x => x.targets == null || x.targets.Count != gltfMesh.extras.targetNames.Length)) {
 								Debug.LogWarning("Morph target names found in mesh " + name + " but array length does not match primitive morph target array length");
 								hasTargetNames = false;
 							}


### PR DESCRIPTION
Exporting models from Maya I get meshes that look like (omitting attribute details for brevity):

```json
{
  "name": "Blob1Shape",
  "extras": {
    "targetNames": []
  },
  "primitives": [
    {
      "attributes": { /*...*/ },
      "indices": 0,
      "mode": 4,
      "material": 0
    }
  ]
}
```

Note that there is no `targets` property on the primitive and the `targetNames` extra is an empty array. The empty `targetNames` array makes `hasTargetNames` (Assets/GLTFUtility/Scripts/Spec/GLTFMesh.cs:200) true causing a check for matching array lengths. The latter previously unconditionally accessed `GLTFPrimitive.targets` which is `null` for this mesh, causing the mesh to not be imported.