### PR TITLE
Added "Unit Scale" option for import settings

### DIFF
--- a/Scripts/Importer.cs
+++ b/Scripts/Importer.cs
@@ -210,9 +210,9 @@ namespace Siccity.GLTFUtility {
 			materialTask.RunSynchronously();
 			GLTFMesh.ImportTask meshTask = new GLTFMesh.ImportTask(gltfObject.meshes, accessorTask, bufferViewTask, materialTask, importSettings);
 			meshTask.RunSynchronously();
-			GLTFSkin.ImportTask skinTask = new GLTFSkin.ImportTask(gltfObject.skins, accessorTask);
+			GLTFSkin.ImportTask skinTask = new GLTFSkin.ImportTask(gltfObject.skins, accessorTask, importSettings.unitScale);
 			skinTask.RunSynchronously();
-			GLTFNode.ImportTask nodeTask = new GLTFNode.ImportTask(gltfObject.nodes, meshTask, skinTask, gltfObject.cameras);
+			GLTFNode.ImportTask nodeTask = new GLTFNode.ImportTask(gltfObject.nodes, meshTask, skinTask, gltfObject.cameras, importSettings.unitScale);
 			nodeTask.RunSynchronously();
 			GLTFAnimation.ImportResult[] animationResult = gltfObject.animations.Import(accessorTask.Result, nodeTask.Result, importSettings);
 			if (animationResult != null) animations = animationResult.Select(x => x.clip).ToArray();
@@ -311,9 +311,9 @@ namespace Siccity.GLTFUtility {
 			importTasks.Add(materialTask);
 			GLTFMesh.ImportTask meshTask = new GLTFMesh.ImportTask(gltfObject.meshes, accessorTask, bufferViewTask, materialTask, importSettings);
 			importTasks.Add(meshTask);
-			GLTFSkin.ImportTask skinTask = new GLTFSkin.ImportTask(gltfObject.skins, accessorTask);
+			GLTFSkin.ImportTask skinTask = new GLTFSkin.ImportTask(gltfObject.skins, accessorTask, importSettings.unitScale);
 			importTasks.Add(skinTask);
-			GLTFNode.ImportTask nodeTask = new GLTFNode.ImportTask(gltfObject.nodes, meshTask, skinTask, gltfObject.cameras);
+			GLTFNode.ImportTask nodeTask = new GLTFNode.ImportTask(gltfObject.nodes, meshTask, skinTask, gltfObject.cameras, importSettings.unitScale);
 			importTasks.Add(nodeTask);
 
 			// Ignite

--- a/Scripts/Settings/ImportSettings.cs
+++ b/Scripts/Settings/ImportSettings.cs
@@ -28,6 +28,9 @@ namespace Siccity.GLTFUtility {
 		[Range(1, 64)]
 		public float packMargin = 4;
 
+		[Range(-1000f, 1000f)]
+		public float unitScale = 1.0f;
+
 		[Tooltip("Script used to process extra data.")]
 		public GLTFExtrasProcessor extrasProcessor;
 	}

--- a/Scripts/Settings/ImportSettings.cs
+++ b/Scripts/Settings/ImportSettings.cs
@@ -28,7 +28,6 @@ namespace Siccity.GLTFUtility {
 		[Range(1, 64)]
 		public float packMargin = 4;
 
-		[Range(-1000f, 1000f)]
 		public float unitScale = 1.0f;
 
 		[Tooltip("Script used to process extra data.")]

--- a/Scripts/Spec/GLTFAnimation.cs
+++ b/Scripts/Spec/GLTFAnimation.cs
@@ -106,9 +106,9 @@ namespace Siccity.GLTFUtility {
 						AnimationCurve posY = new AnimationCurve();
 						AnimationCurve posZ = new AnimationCurve();
 						for (int k = 0; k < keyframeInput.Length; k++) {
-							posX.AddKey(CreateKeyframe(k, keyframeInput, pos, x => -x.x, interpolationMode));
-							posY.AddKey(CreateKeyframe(k, keyframeInput, pos, x => x.y, interpolationMode));
-							posZ.AddKey(CreateKeyframe(k, keyframeInput, pos, x => x.z, interpolationMode));
+							posX.AddKey(CreateKeyframe(k, keyframeInput, pos, x => -x.x*importSettings.unitScale, interpolationMode));
+							posY.AddKey(CreateKeyframe(k, keyframeInput, pos, x => x.y*importSettings.unitScale, interpolationMode));
+							posZ.AddKey(CreateKeyframe(k, keyframeInput, pos, x => x.z*importSettings.unitScale, interpolationMode));
 						}
 						result.clip.SetCurve(relativePath, typeof(Transform), "localPosition.x", posX);
 						result.clip.SetCurve(relativePath, typeof(Transform), "localPosition.y", posY);

--- a/Scripts/Spec/GLTFNode.cs
+++ b/Scripts/Spec/GLTFNode.cs
@@ -43,10 +43,10 @@ namespace Siccity.GLTFUtility {
 		}
 
 		/// <summary> Set local position, rotation and scale </summary>
-		public void ApplyTRS(Transform transform) {
+		public void ApplyTRS(Transform transform, float importScale = 1.0f) {
 			if(matrix!=Matrix4x4.identity)
 				matrix.UnpackTRS(ref translation, ref rotation, ref scale); 
-			transform.localPosition = translation;
+			transform.localPosition = translation * importScale;
 			transform.localRotation = rotation;
 			transform.localScale = scale;
 		}
@@ -57,11 +57,14 @@ namespace Siccity.GLTFUtility {
 			GLTFSkin.ImportTask skinTask;
 			List<GLTFCamera> cameras;
 
-			public ImportTask(List<GLTFNode> nodes, GLTFMesh.ImportTask meshTask, GLTFSkin.ImportTask skinTask, List<GLTFCamera> cameras) : base(meshTask, skinTask) {
+			float importScale;
+
+			public ImportTask(List<GLTFNode> nodes, GLTFMesh.ImportTask meshTask, GLTFSkin.ImportTask skinTask, List<GLTFCamera> cameras, float importScale=1.0f) : base(meshTask, skinTask) {
 				this.nodes = nodes;
 				this.meshTask = meshTask;
 				this.skinTask = skinTask;
 				this.cameras = cameras;
+				this.importScale = importScale;
 				//task = new Task(() => { });
 			}
 
@@ -96,7 +99,7 @@ namespace Siccity.GLTFUtility {
 				}
 				// Apply TRS
 				for (int i = 0; i < Result.Length; i++) {
-					nodes[i].ApplyTRS(Result[i].transform);
+					nodes[i].ApplyTRS(Result[i].transform, this.importScale);
 				}
 				// Setup components
 				for (int i = 0; i < Result.Length; i++) {

--- a/Scripts/Spec/GLTFSkin.cs
+++ b/Scripts/Spec/GLTFSkin.cs
@@ -78,7 +78,7 @@ namespace Siccity.GLTFUtility {
 					Vector4 row2 = m.GetRow(2);
 					row2.x = -row2.x;
 					Vector4 row3 = m.GetRow(3);
-					row3 *= new Vector4(-1.0f, importScale, importScale, importScale);
+					row3 = Vector4.scale(row3, new Vector4(-1.0f, importScale, importScale, importScale));
 					m.SetColumn(0, row0);
 					m.SetColumn(1, row1);
 					m.SetColumn(2, row2);

--- a/Scripts/Spec/GLTFSkin.cs
+++ b/Scripts/Spec/GLTFSkin.cs
@@ -78,7 +78,7 @@ namespace Siccity.GLTFUtility {
 					Vector4 row2 = m.GetRow(2);
 					row2.x = -row2.x;
 					Vector4 row3 = m.GetRow(3);
-					row3 = Vector4.scale(row3, new Vector4(-1.0f, importScale, importScale, importScale));
+					row3 = Vector4.Scale(row3, new Vector4(-importScale, importScale, importScale, 1.0f));
 					m.SetColumn(0, row0);
 					m.SetColumn(1, row1);
 					m.SetColumn(2, row2);

--- a/Scripts/Spec/GLTFSkin.cs
+++ b/Scripts/Spec/GLTFSkin.cs
@@ -14,6 +14,8 @@ namespace Siccity.GLTFUtility {
 		public int? skeleton;
 		public string name;
 
+		public float importScale;
+
 		public class ImportResult {
 			public Matrix4x4[] inverseBindMatrices;
 			public int[] joints;
@@ -53,10 +55,10 @@ namespace Siccity.GLTFUtility {
 			}
 		}
 
-		public ImportResult Import(GLTFAccessor.ImportResult[] accessors) {
+		public ImportResult Import(GLTFAccessor.ImportResult[] accessors, float importScale=1.0f) {
 			ImportResult result = new ImportResult();
 			result.joints = joints;
-
+			this.importScale = importScale;
 			// Inverse bind matrices
 			if (inverseBindMatrices.HasValue) {
 				result.inverseBindMatrices = accessors[inverseBindMatrices.Value].ReadMatrix4x4();
@@ -77,6 +79,9 @@ namespace Siccity.GLTFUtility {
 					row2.x = -row2.x;
 					Vector4 row3 = m.GetRow(3);
 					row3.x = -row3.x;
+					row3.x *= importScale;
+					row3.y *= importScale;
+					row3.z *= importScale;
 					m.SetColumn(0, row0);
 					m.SetColumn(1, row1);
 					m.SetColumn(2, row2);
@@ -88,13 +93,13 @@ namespace Siccity.GLTFUtility {
 		}
 
 		public class ImportTask : Importer.ImportTask<ImportResult[]> {
-			public ImportTask(List<GLTFSkin> skins, GLTFAccessor.ImportTask accessorTask) : base(accessorTask) {
+			public ImportTask(List<GLTFSkin> skins, GLTFAccessor.ImportTask accessorTask, float importScale=1.0f) : base(accessorTask) {
 				task = new Task(() => {
 					if (skins == null) return;
 
 					Result = new ImportResult[skins.Count];
 					for (int i = 0; i < Result.Length; i++) {
-						Result[i] = skins[i].Import(accessorTask.Result);
+						Result[i] = skins[i].Import(accessorTask.Result, importScale);
 					}
 				});
 			}

--- a/Scripts/Spec/GLTFSkin.cs
+++ b/Scripts/Spec/GLTFSkin.cs
@@ -78,10 +78,7 @@ namespace Siccity.GLTFUtility {
 					Vector4 row2 = m.GetRow(2);
 					row2.x = -row2.x;
 					Vector4 row3 = m.GetRow(3);
-					row3.x = -row3.x;
-					row3.x *= importScale;
-					row3.y *= importScale;
-					row3.z *= importScale;
+					row3 *= new Vector4(-1.0f, importScale, importScale, importScale);
 					m.SetColumn(0, row0);
 					m.SetColumn(1, row1);
 					m.SetColumn(2, row2);


### PR DESCRIPTION
This allows you to change the import scale of meshes and assets to better align with features from other importers

Tested to be compatible with mesh swapping from FBX exported armatures

![image](https://github.com/user-attachments/assets/7894b1be-de80-4660-a9d1-706330c9eccf)

Made sure to affect all forms of translation, including bone positions, bone positions in keyframes, and bind poses for bones